### PR TITLE
update passwall repo urls

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -136,9 +136,9 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}-${{ matrix.ref }}
           EXTRA_FEEDS: >-
-            src-git|passwall_packages|https://github.com/xiaorouji/openwrt-passwall-packages^${{ steps.ver.outputs.packages }}
-            src-git|passwall_luci|https://github.com/xiaorouji/openwrt-passwall^${{ steps.ver.outputs.passwall }}
-            src-git|passwall2|https://github.com/xiaorouji/openwrt-passwall2^${{ steps.ver.outputs.passwall2 }}
+            src-git|passwall_packages|https://github.com/Openwrt-Passwall/openwrt-passwall-packages^${{ steps.ver.outputs.packages }}
+            src-git|passwall_luci|https://github.com/Openwrt-Passwall/openwrt-passwall^${{ steps.ver.outputs.passwall }}
+            src-git|passwall2|https://github.com/Openwrt-Passwall/openwrt-passwall2^${{ steps.ver.outputs.passwall2 }}
           KEY_BUILD: ${{ secrets.SIGN_PRIV_KEY }}
           V: s
           IGNORE_ERRORS: n m y

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,9 +31,9 @@ jobs:
         env:
           ARCH: ${{ github.event.inputs.arch }}-${{ github.event.inputs.sdk_version }}
           EXTRA_FEEDS: >-
-            src-git|passwall_packages|https://github.com/xiaorouji/openwrt-passwall-packages;main
-            src-git|passwall_luci|https://github.com/xiaorouji/openwrt-passwall;main
-            src-git|passwall2|https://github.com/xiaorouji/openwrt-passwall2;main
+            src-git|passwall_packages|https://github.com/Openwrt-Passwall/openwrt-passwall-packages;main
+            src-git|passwall_luci|https://github.com/Openwrt-Passwall/openwrt-passwall;main
+            src-git|passwall2|https://github.com/Openwrt-Passwall/openwrt-passwall2;main
           KEY_BUILD: ${{ secrets.SIGN_PRIV_KEY }}
           V: s
           GOLANG_COMMIT: ${{ github.event.inputs.golang_commit }}

--- a/.github/workflows/version-scan.yml
+++ b/.github/workflows/version-scan.yml
@@ -38,6 +38,6 @@ jobs:
           commit_message: |
             chore: bump version
 
-            passwall: xiaorouji/openwrt-passwall@${{ steps.compare_version.outputs.passwall }}
-            passwall2: xiaorouji/openwrt-passwall2@${{ steps.compare_version.outputs.passwall2 }}
-            packages: xiaorouji/openwrt-passwall-packages@${{ steps.compare_version.outputs.packages }}
+            passwall: Openwrt-Passwall/openwrt-passwall@${{ steps.compare_version.outputs.passwall }}
+            passwall2: Openwrt-Passwall/openwrt-passwall2@${{ steps.compare_version.outputs.passwall2 }}
+            packages: Openwrt-Passwall/openwrt-passwall-packages@${{ steps.compare_version.outputs.packages }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openwrt-passwall-build
 
-Binary distribution of [xiaorouji/openwrt-passwall](https://github.com/xiaorouji/openwrt-passwall) built with official OpenWRT SDK.
+Binary distribution of [Openwrt-Passwall/openwrt-passwall](https://github.com/Openwrt-Passwall/openwrt-passwall) built with official OpenWRT SDK.
 
 [![Build and Release](https://github.com/dianlujitao/openwrt-passwall-build/actions/workflows/build-release.yml/badge.svg)](https://github.com/dianlujitao/openwrt-passwall-build/actions/workflows/build-release.yml)
 [![Scan openwrt-passwall Version](https://github.com/dianlujitao/openwrt-passwall-build/actions/workflows/version-scan.yml/badge.svg)](https://github.com/dianlujitao/openwrt-passwall-build/actions/workflows/version-scan.yml)

--- a/nvchecker.toml
+++ b/nvchecker.toml
@@ -4,15 +4,15 @@ newver = "new_ver.json"
 
 [passwall]
 source = "git"
-git = "https://github.com/xiaorouji/openwrt-passwall"
+git = "https://github.com/Openwrt-Passwall/openwrt-passwall"
 use_commit = true
 
 [passwall2]
 source = "git"
-git = "https://github.com/xiaorouji/openwrt-passwall2"
+git = "https://github.com/Openwrt-Passwall/openwrt-passwall2"
 use_commit = true
 
 [packages]
 source = "git"
-git = "https://github.com/xiaorouji/openwrt-passwall-packages"
+git = "https://github.com/Openwrt-Passwall/openwrt-passwall-packages"
 use_commit = true


### PR DESCRIPTION
The passwall repository has been moved to the **Openwrt-Passwall** organization, and the original link is no longer redirecting to the new one.